### PR TITLE
fix: set fetch-depth to 0 in Chromatic workflow

### DIFF
--- a/.changeset/violet-guests-call.md
+++ b/.changeset/violet-guests-call.md
@@ -1,0 +1,5 @@
+---
+"antd-multi-dashboard": patch
+---
+
+fix: set fetch-depth to 0 in Chromatic workflow

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,6 +16,8 @@ jobs:
     # Job steps
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,8 +27,7 @@ jobs:
         #👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest
-        # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build-storybook
+          exit-zero-on-errors: true

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,13 +1,24 @@
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
+import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
-import { store } from '../src/redux/store';
+import themeReducer from '../src/redux/theme/themeSlice';
+import dataModeReducer from '../src/redux/data-mode/dataModeSlice';
+import authReducer from '../src/redux/auth/authSlice';
 import { StylesContext } from '../src/context';
 import '../src/App.css';
 
+const storybookStore = configureStore({
+  reducer: {
+    theme: themeReducer,
+    dataMode: dataModeReducer,
+    auth: authReducer,
+  },
+});
+
 export const withStylesProvider = (Story: any) => {
   return (
-    <Provider store={store}>
+    <Provider store={storybookStore}>
       <StylesContext.Provider value={null}>
         <Story />
       </StylesContext.Provider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -27,6 +27,7 @@ export const withStylesProvider = (Story: any) => {
 };
 
 const preview: Preview = {
+  decorators: [withStylesProvider],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
@@ -38,7 +39,6 @@ const preview: Preview = {
     docs: {
       theme: themes.normal,
     },
-    decorators: [withStylesProvider],
   },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,14 +1,17 @@
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
+import { Provider } from 'react-redux';
+import { store } from '../src/redux/store';
 import { StylesContext } from '../src/context';
 import '../src/App.css';
 
 export const withStylesProvider = (Story: any) => {
   return (
-    <StylesContext.Provider value={null}>
-      {/* 👇 Decorators in Storybook also accept a function. Replace <Story/> with Story() to enable it  */}
-      <Story />
-    </StylesContext.Provider>
+    <Provider store={store}>
+      <StylesContext.Provider value={null}>
+        <Story />
+      </StylesContext.Provider>
+    </Provider>
   );
 };
 
@@ -24,7 +27,7 @@ const preview: Preview = {
     docs: {
       theme: themes.normal,
     },
-    decorators: [],
+    decorators: [withStylesProvider],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lint-staged": "^16.2.7",
     "prettier": "3.1.1",
     "sass": "^1.66.1",
-    "storybook": "10.1.11",
+    "storybook": "8.6.14",
     "storybook-addon-react-router-v6": "^2.0.8",
     "storybook-react-context": "^0.6.0",
     "typescript": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,34 +88,34 @@ importers:
         version: 20.4.1
       '@storybook/addon-essentials':
         specifier: 8.6.14
-        version: 8.6.14(@types/react@18.3.27)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(@types/react@18.3.27)(storybook@8.6.14(prettier@3.1.1))
       '@storybook/addon-interactions':
         specifier: 8.6.14
-        version: 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/addon-links':
         specifier: 8.6.14
-        version: 8.6.14(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
       '@storybook/addon-onboarding':
         specifier: 8.6.14
-        version: 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/blocks':
         specifier: 8.6.14
-        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
       '@storybook/manager-api':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/react':
         specifier: 8.6.14
-        version: 8.6.14(@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 8.6.14
-        version: 8.6.14(@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.53.3)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.53.3)(storybook@8.6.14(prettier@3.1.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))
       '@storybook/test':
         specifier: 8.6.14
-        version: 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/theming':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@types/lodash':
         specifier: ^4.14.197
         version: 4.17.20
@@ -171,11 +171,11 @@ importers:
         specifier: ^1.66.1
         version: 1.94.1
       storybook:
-        specifier: 10.1.11
-        version: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 8.6.14
+        version: 8.6.14(prettier@3.1.1)
       storybook-addon-react-router-v6:
         specifier: ^2.0.8
-        version: 2.0.15(@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/channels@7.6.20)(@storybook/components@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/preview-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/theming@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.15(@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1)))(@storybook/channels@7.6.20)(@storybook/components@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       storybook-react-context:
         specifier: ^0.6.0
         version: 0.6.0(react-dom@18.3.1(react@18.3.1))
@@ -2201,6 +2201,17 @@ packages:
         integrity: sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==,
       }
 
+  '@storybook/core@8.6.14':
+    resolution:
+      {
+        integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==,
+      }
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   '@storybook/csf-plugin@8.6.14':
     resolution:
       {
@@ -2236,15 +2247,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-
-  '@storybook/icons@2.0.1':
-    resolution:
-      {
-        integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@storybook/instrumenter@8.6.14':
     resolution:
@@ -2522,26 +2524,10 @@ packages:
       }
     engines: { node: '>=14', npm: '>=6', yarn: '>=1' }
 
-  '@testing-library/jest-dom@6.9.1':
-    resolution:
-      {
-        integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==,
-      }
-    engines: { node: '>=14', npm: '>=6', yarn: '>=1' }
-
   '@testing-library/user-event@14.5.2':
     resolution:
       {
         integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==,
-      }
-    engines: { node: '>=12', npm: '>=6' }
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
-
-  '@testing-library/user-event@14.6.1':
-    resolution:
-      {
-        integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==,
       }
     engines: { node: '>=12', npm: '>=6' }
     peerDependencies:
@@ -2625,22 +2611,10 @@ packages:
         integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
       }
 
-  '@types/chai@5.2.3':
-    resolution:
-      {
-        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-      }
-
   '@types/d3-timer@2.0.3':
     resolution:
       {
         integrity: sha512-jhAJzaanK5LqyLQ50jJNIrB8fjL9gwWZTgYjevPvkDLMU+kTAZkYsobI59nYoeSrH1PucuyJEi247Pb90t6XUg==,
-      }
-
-  '@types/deep-eql@4.0.2':
-    resolution:
-      {
-        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
   '@types/doctrine@0.0.9':
@@ -2953,12 +2927,6 @@ packages:
         integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==,
       }
 
-  '@vitest/expect@3.2.4':
-    resolution:
-      {
-        integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
-      }
-
   '@vitest/pretty-format@2.0.5':
     resolution:
       {
@@ -2971,22 +2939,10 @@ packages:
         integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
       }
 
-  '@vitest/pretty-format@3.2.4':
-    resolution:
-      {
-        integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
-      }
-
   '@vitest/spy@2.0.5':
     resolution:
       {
         integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==,
-      }
-
-  '@vitest/spy@3.2.4':
-    resolution:
-      {
-        integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
       }
 
   '@vitest/utils@2.0.5':
@@ -2999,12 +2955,6 @@ packages:
     resolution:
       {
         integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
-      }
-
-  '@vitest/utils@3.2.4':
-    resolution:
-      {
-        integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
       }
 
   '@webgpu/glslang@0.0.15':
@@ -3294,6 +3244,13 @@ packages:
         integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==,
       }
 
+  better-opn@3.0.2:
+    resolution:
+      {
+        integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==,
+      }
+    engines: { node: '>=12.0.0' }
+
   better-path-resolve@1.0.0:
     resolution:
       {
@@ -3333,13 +3290,6 @@ packages:
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
-
-  bundle-name@4.1.0:
-    resolution:
-      {
-        integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==,
-      }
-    engines: { node: '>=18' }
 
   bytewise-core@1.2.3:
     resolution:
@@ -3933,20 +3883,6 @@ packages:
         integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
       }
 
-  default-browser-id@5.0.1:
-    resolution:
-      {
-        integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==,
-      }
-    engines: { node: '>=18' }
-
-  default-browser@5.5.0:
-    resolution:
-      {
-        integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==,
-      }
-    engines: { node: '>=18' }
-
   define-data-property@1.1.4:
     resolution:
       {
@@ -3954,12 +3890,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  define-lazy-prop@3.0.0:
+  define-lazy-prop@2.0.0:
     resolution:
       {
-        integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==,
+        integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==,
       }
-    engines: { node: '>=12' }
+    engines: { node: '>=8' }
 
   define-properties@1.2.1:
     resolution:
@@ -4190,6 +4126,14 @@ packages:
         integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
       }
     engines: { node: '>= 0.4' }
+
+  esbuild-register@3.6.0:
+    resolution:
+      {
+        integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==,
+      }
+    peerDependencies:
+      esbuild: '>=0.12 <1'
 
   esbuild@0.21.5:
     resolution:
@@ -5084,12 +5028,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  is-docker@3.0.0:
+  is-docker@2.2.1:
     resolution:
       {
-        integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==,
+        integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==,
       }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    engines: { node: '>=8' }
     hasBin: true
 
   is-extendable@0.1.1:
@@ -5153,14 +5097,6 @@ packages:
         integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
       }
     engines: { node: '>=0.10.0' }
-
-  is-inside-container@1.0.0:
-    resolution:
-      {
-        integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==,
-      }
-    engines: { node: '>=14.16' }
-    hasBin: true
 
   is-map@2.0.3:
     resolution:
@@ -5309,12 +5245,12 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
-  is-wsl@3.1.0:
+  is-wsl@2.2.0:
     resolution:
       {
-        integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==,
+        integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
       }
-    engines: { node: '>=16' }
+    engines: { node: '>=8' }
 
   isarray@2.0.5:
     resolution:
@@ -5392,6 +5328,13 @@ packages:
         integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
       }
     hasBin: true
+
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution:
+      {
+        integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==,
+      }
+    engines: { node: '>=12.0.0' }
 
   jsesc@3.1.0:
     resolution:
@@ -5980,12 +5923,12 @@ packages:
       }
     engines: { node: '>=18' }
 
-  open@10.2.0:
+  open@8.4.2:
     resolution:
       {
-        integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==,
+        integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==,
       }
-    engines: { node: '>=18' }
+    engines: { node: '>=12' }
 
   optionator@0.9.4:
     resolution:
@@ -7144,13 +7087,6 @@ packages:
         integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==,
       }
 
-  run-applescript@7.1.0:
-    resolution:
-      {
-        integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==,
-      }
-    engines: { node: '>=18' }
-
   run-parallel@1.2.0:
     resolution:
       {
@@ -7520,10 +7456,10 @@ packages:
         integrity: sha512-6IOUbSoC1WW68x8zQBEh8tZsVXjEvOBSJSOhkaD9o8IF9caIg/o1jnwuGibdyAd47ARN6g95O0N0vFBjXcB7pA==,
       }
 
-  storybook@10.1.11:
+  storybook@8.6.14:
     resolution:
       {
-        integrity: sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==,
+        integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==,
       }
     hasBin: true
     peerDependencies:
@@ -7760,24 +7696,10 @@ packages:
       }
     engines: { node: '>=14.0.0' }
 
-  tinyrainbow@2.0.0:
-    resolution:
-      {
-        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
-      }
-    engines: { node: '>=14.0.0' }
-
   tinyspy@3.0.2:
     resolution:
       {
         integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
-      }
-    engines: { node: '>=14.0.0' }
-
-  tinyspy@4.0.4:
-    resolution:
-      {
-        integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
       }
     engines: { node: '>=14.0.0' }
 
@@ -8003,6 +7925,12 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  util@0.12.5:
+    resolution:
+      {
+        integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
+      }
+
   utility-types@3.11.0:
     resolution:
       {
@@ -8181,13 +8109,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  wsl-utils@0.1.0:
-    resolution:
-      {
-        integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==,
-      }
-    engines: { node: '>=18' }
 
   y18n@5.0.8:
     resolution:
@@ -9754,104 +9675,104 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-actions@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@18.3.27)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-docs@8.6.14(@types/react@18.3.27)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/csf-plugin': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.14(@types/react@18.3.27)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-essentials@8.6.14(@types/react@18.3.27)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-controls': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-docs': 8.6.14(@types/react@18.3.27)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-highlight': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-measure': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-outline': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-toolbars': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/addon-viewport': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-docs': 8.6.14(@types/react@18.3.27)(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/addon-interactions@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-interactions@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/test': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       polished: 4.3.1
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.6.14(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-links@8.6.14(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/addon-measure@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-onboarding@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-onboarding@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/addon-outline@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/addon-viewport@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
   '@storybook/addons@6.5.16(react-dom@18.3.1(react@18.3.1))(react@17.0.2)':
     dependencies:
@@ -9891,20 +9812,20 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))':
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.1.1))(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))':
     dependencies:
-      '@storybook/csf-plugin': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       browser-assert: 1.2.1
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       ts-dedent: 2.2.0
       vite: 5.4.21(@types/node@24.10.1)(sass@1.94.1)
 
@@ -9932,9 +9853,9 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/components@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
   '@storybook/core-events@6.5.16':
     dependencies:
@@ -9944,9 +9865,30 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/core@8.6.14(prettier@3.1.1)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.21.5
+      esbuild-register: 3.6.0(esbuild@0.21.5)
+      jsdoc-type-pratt-parser: 4.8.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.3
+      util: 0.12.5
+      ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+
+  '@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.1.1))':
+    dependencies:
+      storybook: 8.6.14(prettier@3.1.1)
       unplugin: 1.16.1
 
   '@storybook/csf@0.0.1':
@@ -9964,66 +9906,61 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@storybook/instrumenter@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/manager-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/preview-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
-  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.53.3)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))':
+  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.53.3)(storybook@8.6.14(prettier@3.1.1))(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
-      '@storybook/builder-vite': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))
-      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.1.1))(vite@5.4.21(@types/node@24.10.1)(sass@1.94.1))
+      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))(typescript@5.9.3)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 7.1.1
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
       tsconfig-paths: 4.2.0
       vite: 5.4.21(@types/node@24.10.1)(sass@1.94.1)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.1.1))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))(typescript@5.9.3)':
     dependencies:
-      '@storybook/components': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/preview-api': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/theming': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       typescript: 5.9.3
 
   '@storybook/router@6.5.16(react-dom@18.3.1(react@18.3.1))(react@17.0.2)':
@@ -10041,16 +9978,16 @@ snapshots:
       core-js: 3.47.0
       find-up: 4.1.0
 
-  '@storybook/test@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/test@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
   '@storybook/theming@6.5.16(react-dom@18.3.1(react@18.3.1))(react@17.0.2)':
     dependencies:
@@ -10061,9 +9998,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
 
-  '@storybook/theming@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.1.1))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.6.14(prettier@3.1.1)
 
   '@swc/core-darwin-arm64@1.15.2':
     optional: true
@@ -10160,20 +10097,7 @@ snapshots:
       lodash: 4.17.23
       redent: 3.0.0
 
-  '@testing-library/jest-dom@6.9.1':
-    dependencies:
-      '@adobe/css-tools': 4.4.4
-      aria-query: 5.3.2
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.6.3
-      picocolors: 1.1.1
-      redent: 3.0.0
-
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
-    dependencies:
-      '@testing-library/dom': 10.4.0
-
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -10234,14 +10158,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/chai@5.2.3':
-    dependencies:
-      '@types/deep-eql': 4.0.2
-      assertion-error: 2.0.1
-
   '@types/d3-timer@2.0.3': {}
-
-  '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -10466,14 +10383,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/expect@3.2.4':
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
-
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -10482,17 +10391,9 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/pretty-format@3.2.4':
-    dependencies:
-      tinyrainbow: 2.0.0
-
   '@vitest/spy@2.0.5':
     dependencies:
       tinyspy: 3.0.2
-
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -10506,12 +10407,6 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
-
-  '@vitest/utils@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
 
   '@webgpu/glslang@0.0.15': {}
 
@@ -10702,6 +10597,10 @@ snapshots:
 
   batch-processor@1.0.0: {}
 
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -10728,10 +10627,6 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  bundle-name@4.1.0:
-    dependencies:
-      run-applescript: 7.1.0
 
   bytewise-core@1.2.3:
     dependencies:
@@ -11054,20 +10949,13 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  default-browser-id@5.0.1: {}
-
-  default-browser@5.5.0:
-    dependencies:
-      bundle-name: 4.1.0
-      default-browser-id: 5.0.1
-
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  define-lazy-prop@3.0.0: {}
+  define-lazy-prop@2.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -11233,6 +11121,13 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild-register@3.6.0(esbuild@0.21.5):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.21.5
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -11778,7 +11673,7 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-docker@3.0.0: {}
+  is-docker@2.2.1: {}
 
   is-extendable@0.1.1: {}
 
@@ -11811,10 +11706,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-inside-container@1.0.0:
-    dependencies:
-      is-docker: 3.0.0
 
   is-map@2.0.3: {}
 
@@ -11889,9 +11780,9 @@ snapshots:
 
   is-windows@1.0.2: {}
 
-  is-wsl@3.1.0:
+  is-wsl@2.2.0:
     dependencies:
-      is-inside-container: 1.0.0
+      is-docker: 2.2.1
 
   isarray@2.0.5: {}
 
@@ -11927,6 +11818,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@4.8.0: {}
 
   jsesc@3.1.0: {}
 
@@ -12268,12 +12161,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  open@10.2.0:
+  open@8.4.2:
     dependencies:
-      default-browser: 5.5.0
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -13122,8 +13014,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
 
-  run-applescript@7.1.0: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -13329,15 +13219,15 @@ snapshots:
 
   store2@2.14.4: {}
 
-  storybook-addon-react-router-v6@2.0.15(@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/channels@7.6.20)(@storybook/components@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/preview-api@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/theming@8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  storybook-addon-react-router-v6@2.0.15(@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1)))(@storybook/channels@7.6.20)(@storybook/components@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/core-events@7.6.20)(@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.1.1)))(@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.1.1)))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.1.1))
       '@storybook/channels': 7.6.20
-      '@storybook/components': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       '@storybook/core-events': 7.6.20
-      '@storybook/manager-api': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/preview-api': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/theming': 8.6.14(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.1.1))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.1.1))
       compare-versions: 6.1.1
       react-inspector: 6.0.2(react@18.3.1)
       react-router-dom: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13353,27 +13243,14 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@8.6.14(prettier@3.1.1):
     dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      esbuild: 0.21.5
-      open: 10.2.0
-      recast: 0.23.11
-      semver: 7.7.3
-      use-sync-external-store: 1.6.0(react@18.3.1)
-      ws: 8.19.0
+      '@storybook/core': 8.6.14(prettier@3.1.1)(storybook@8.6.14(prettier@3.1.1))
     optionalDependencies:
       prettier: 3.1.1
     transitivePeerDependencies:
-      - '@testing-library/dom'
       - bufferutil
-      - react
-      - react-dom
+      - supports-color
       - utf-8-validate
 
   string-argv@0.3.2: {}
@@ -13518,11 +13395,7 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
-  tinyrainbow@2.0.0: {}
-
   tinyspy@3.0.2: {}
-
-  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13657,6 +13530,14 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
+
   utility-types@3.11.0: {}
 
   uuid@9.0.1: {}
@@ -13762,10 +13643,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
-
-  wsl-utils@0.1.0:
-    dependencies:
-      is-wsl: 3.1.0
 
   y18n@5.0.8: {}
 

--- a/src/components/corporate/blogs-list-card/blog-list-card.stories.tsx
+++ b/src/components/corporate/blogs-list-card/blog-list-card.stories.tsx
@@ -39,12 +39,14 @@ export const Default: Story = {
 
 export const Loading: Story = {
   args: {
+    data: [],
     loading: true,
   },
 };
 
 export const Error: Story = {
   args: {
+    data: [],
     error: 'Failed to fetch blogs',
   },
 };


### PR DESCRIPTION
## Summary

Fixes the Chromatic deployment failure by setting `fetch-depth: 0` in the GitHub Actions checkout step. This enables Chromatic to access the full git history for baseline change detection.

## Type

- [x] Fix

## Testing

- Verify the workflow runs successfully on the next push/PR