### PR TITLE
ci: update workflows to Node 20 and pnpm

### DIFF
--- a/.changeset/blue-vans-press.md
+++ b/.changeset/blue-vans-press.md
@@ -1,0 +1,5 @@
+---
+"antd-multi-dashboard": patch
+---
+
+ci: update workflows to Node 20 and pnpm

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,11 +19,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
         with:
-          version: latest
+          node-version: 20
+          cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
         #👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
-        uses: actions/setup-node@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Install Dependencies
-        run: yarn
+        run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- **Fix release pipeline failure**: `lint-staged@16.2.7` requires Node >= 20.17, but the workflow was using Node 18
- **Switch release workflow from yarn to pnpm** to match the project's package manager
- **Update chromatic workflow**: bump `pnpm/action-setup` to v4, pin Node 20, add pnpm caching

## Changes
- `.github/workflows/release.yml`: Node 18 → 20, yarn → pnpm, bump actions to v4, add caching
- `.github/workflows/chromatic.yml`: bump pnpm/action-setup to v4, add Node 20 setup with caching, use `--frozen-lockfile`

## Test plan
- [ ] Verify release workflow passes on push to main
- [ ] Verify chromatic deployment workflow passes on PR/push to main